### PR TITLE
Fix monitoring servers module

### DIFF
--- a/modules/LevelsRanks/module_block_main_servers_monitoring/includes/ServerJS.php
+++ b/modules/LevelsRanks/module_block_main_servers_monitoring/includes/ServerJS.php
@@ -109,6 +109,7 @@ for ( $i_server = 0; $i_server < $servers_count; $i_server++ ):
 
         // Количество игроков выключенного сервера
         $return[ $i_server ]['Players'] = 0;
+        $return[ $i_server ]['players'] = 0;
         $return[ $i_server ]['MaxPlayers'] = 0;
 
         // Мод выключенного сервера

--- a/modules/LevelsRanks/module_block_main_servers_monitoring/includes/ServerJS.php
+++ b/modules/LevelsRanks/module_block_main_servers_monitoring/includes/ServerJS.php
@@ -109,7 +109,7 @@ for ( $i_server = 0; $i_server < $servers_count; $i_server++ ):
 
         // Количество игроков выключенного сервера
         $return[ $i_server ]['Players'] = 0;
-        $return[ $i_server ]['players'] = 0;
+        $return[ $i_server ]['players'] = [];
         $return[ $i_server ]['MaxPlayers'] = 0;
 
         // Мод выключенного сервера


### PR DESCRIPTION
When there are many servers on a page, and one of them is disabled in the middle, an error occurred due to non-compliance with the data contract, this PR fixes this error