### PR TITLE
Fix stops displaying the next servers' status

### DIFF
--- a/web_dev/app/modules/module_block_main_servers_monitoring/includes/ServerJS.php
+++ b/web_dev/app/modules/module_block_main_servers_monitoring/includes/ServerJS.php
@@ -109,6 +109,7 @@ for ( $i_server = 0; $i_server < $servers_count; $i_server++ ):
 
         // Количество игроков выключенного сервера
         $return[ $i_server ]['Players'] = 0;
+        $return[ $i_server ]['players'] = [];
         $return[ $i_server ]['MaxPlayers'] = 0;
 
         // Мод выключенного сервера


### PR DESCRIPTION
Bug : Stops displaying the next servers' status when one is unavailable