### PR TITLE
Added translation of the download demo button

### DIFF
--- a/web_dev/storage/cache/sessions/translator.php
+++ b/web_dev/storage/cache/sessions/translator.php
@@ -1305,5 +1305,11 @@ return array (
             'UA' => 'Неізвестноi',
             'LT' => 'Nežinoma',
             'TR' => 'Bilinmeyen'
+        ),
+    '_Download' =>
+        array (
+            'EN' => 'Download match demo',
+            'RU' => 'Скачать демо матча',
+            'UA' => 'Завантажити демо матчу',
         )
 );


### PR DESCRIPTION
In the file /app/modules/module_page_demos/includes/match.php on line 145, replace Скачать демо матча with <? Php echo $ Translate-> get_translate_phrase ('_ Download')?> In the Admin panel update the translation cache