### PR TITLE
fixed CSS class for active table

### DIFF
--- a/app/modules/module_page_profiles/forward/interface.php
+++ b/app/modules/module_page_profiles/forward/interface.php
@@ -197,7 +197,7 @@
 						</thead>
 						<tbody>
 							<?php for ( $ti = 0, $sizelist = 10 + (int) ($Player->top_position > 6); $ti < $sizelist; $ti++ ):?>
-							<tr class="pointer<?php ! empty( $Player->top_with_player[ $ti ]['steam'] ) && $Player->get_steam_32() == $Player->top_with_player[ $ti ]['steam'] && print 'table-active'?>" onclick="location.href = '<?php echo $General->arr_general['site']?>profiles/<?php print $General->arr_general['only_steam_64'] === 1 ? con_steam32to64( $Player->top_with_player[$ti]['steam'] ) : $Player->top_with_player[$ti]['steam']?>/<?php echo $Player->server_group ?>/';">
+							<tr class="pointer<?php ! empty( $Player->top_with_player[ $ti ]['steam'] ) && $Player->get_steam_32() == $Player->top_with_player[ $ti ]['steam'] && print ' table-active'?>" onclick="location.href = '<?php echo $General->arr_general['site']?>profiles/<?php print $General->arr_general['only_steam_64'] === 1 ? con_steam32to64( $Player->top_with_player[$ti]['steam'] ) : $Player->top_with_player[$ti]['steam']?>/<?php echo $Player->server_group ?>/';">
 								<th class="text-center"><?php echo $Player->top_with_player['countdown_from']++?></th>
 								<th class="table-text"><?php echo empty( $Player->top_with_player[ $ti ]['name'] ) ? 'Unnamed' : action_text_trim( $Player->top_with_player[ $ti ]['name'],16 )?></th>
 								<th class="text-center"><?php echo empty( $Player->top_with_player[ $ti ]['value'] ) ? 0 : $Player->top_with_player[ $ti ]['value']?></th>


### PR DESCRIPTION
The CSS class for active table entry was set wrong on the profile page. Adding a whitespace resolves that issue.