### PR TITLE
Not complying with RFC 3986 Fix

### DIFF
--- a/app/ext/AltoRouter.php
+++ b/app/ext/AltoRouter.php
@@ -59,7 +59,19 @@ class AltoRouter
     {
         $server = $_SERVER['REQUEST_URI'];
         $replace = substr($server, strlen($this->basePath));
-        $match = explode("/", $replace);
+        $first_query_param_index = strpos($replace, "?");
+        $fragment_index = strpos($replace, "#");
+
+        // Determine query params / fragments cutoff
+        $filter_length = strlen($replace);
+        if ($first_query_param_index) {
+            $filter_length = $first_query_param_index;
+        } else if ($fragment_index) {
+            $filter_length = $fragment_index;
+        }
+
+        $filtered_uri = substr($replace, 0, $filter_length);
+        $match = explode("/", $filtered_uri);
         return $match[0];
     }
 

--- a/app/includes/functions.php
+++ b/app/includes/functions.php
@@ -171,7 +171,7 @@ function set_url_section( $url, $command, $change ) {
 
     // Генерируем новую ссылку.
     $finally = urldecode( http_build_query( $query ) );
-    return $url . '?' . $finally;
+    return $url . '/?' . $finally;
 }
 
 /**

--- a/app/includes/functions.php
+++ b/app/includes/functions.php
@@ -171,7 +171,7 @@ function set_url_section( $url, $command, $change ) {
 
     // Генерируем новую ссылку.
     $finally = urldecode( http_build_query( $query ) );
-    return $url . '/?' . $finally;
+    return $url . '?' . $finally;
 }
 
 /**

--- a/app/modules/module_page_adminpanel/ext/Admin.php
+++ b/app/modules/module_page_adminpanel/ext/Admin.php
@@ -34,9 +34,7 @@ class Admin
     //Позволяет обновить страницу без проблем с кавычками
     function ReloadPage()
     {
-        if (strlen($_SERVER['QUERY_STRING']) > 0) {
-            header("Location: ?".$_SERVER['QUERY_STRING']);
-        }
+        header("Location: ?".$_SERVER['QUERY_STRING']);
     }
 
     // Очистка кеша шаблонов

--- a/app/modules/module_page_adminpanel/ext/Admin.php
+++ b/app/modules/module_page_adminpanel/ext/Admin.php
@@ -34,7 +34,9 @@ class Admin
     //Позволяет обновить страницу без проблем с кавычками
     function ReloadPage()
     {
-        header("Location: ?".$_SERVER['QUERY_STRING']);
+        if (strlen($_SERVER['QUERY_STRING']) > 0) {
+            header("Location: ?".$_SERVER['QUERY_STRING']);
+        }
     }
 
     // Очистка кеша шаблонов

--- a/app/modules/module_page_profiles/forward/data.php
+++ b/app/modules/module_page_profiles/forward/data.php
@@ -10,8 +10,8 @@
 
 use app\modules\module_page_profiles\ext\Player;
 
-$Router->map( 'GET|POST', 'profiles/[:id]/', 'profiles' );
-$Router->map( 'GET|POST', 'profiles/[:id]/[i:sid]/', 'profiles' );
+$Router->map( 'GET|POST', 'profiles/[:id]/?', 'profiles' );
+$Router->map( 'GET|POST', 'profiles/[:id]/[i:sid]/?', 'profiles' );
 
 $Map = $Router->match();
 


### PR DESCRIPTION
Reloading admin panel after request without any query parameters provided (clear module cache, for example) results in 404 because we're targeting endpoint `/adminpanel?` instead of `/adminpanel`